### PR TITLE
add qudt namespace

### DIFF
--- a/csvwlib/converter/ToRDFConverter.py
+++ b/csvwlib/converter/ToRDFConverter.py
@@ -82,7 +82,7 @@ class ToRDFConverter:
                     self.graph.add((row_node, CSVW.describes, subject))
             else:
                 print(f"term {virtual_column['propertyUrl']} not in namespaces")
-S
+
     def _add_file_metadata(self, metadata, node):
         language = JSONLDUtils.language(self.metadata.get('@context',[]))
         for key, value in metadata.items():

--- a/csvwlib/utils/rdf/Namespaces.py
+++ b/csvwlib/utils/rdf/Namespaces.py
@@ -25,6 +25,7 @@ class Namespaces:
             'org': Namespace('http://www.w3.org/ns/org#'),
             'owl': Namespace('http://www.w3.org/2002/07/owl#'),
             'prov': Namespace('http://www.w3.org/ns/prov#'),
+            'qudt': Namespace('http://qudt.org/1.1/schema/qudt#'),
             'qb': Namespace('http://purl.org/linked-data/cube#'),
             'rdf': Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#'),
             'rdfa': Namespace('http://www.w3.org/ns/rdfa#'),


### PR DESCRIPTION
the qudt namespace is quite used with [sosa/ssn](https://www.w3.org/TR/vocab-ssn/#quantity-values-and-unit-of-measures), suggestion to add it, also adds a warning if a term from a namespace is used which is not registered, instead of trying to parse as None. 

- add qudt namespace
- warn for term in missing namespace