### PR TITLE
col:name and col:titles are not required, 

### DIFF
--- a/csvwlib/converter/ModelConverter.py
+++ b/csvwlib/converter/ModelConverter.py
@@ -201,7 +201,9 @@ class ModelConverter:
             for i, column in enumerate(table['tableSchema']['columns'], start=1):
                 if 'name' not in column:
                     language = JSONLDUtils.language(self.metadata['@context'], table)
-                    titles = column['titles'] if type(column['titles']) is list else [column['titles']]
+                    titles = column.get('titles',[]) 
+                    if type(titles) is not list:
+                        titles = [titles]
                     if language is None:
                         column['name'] = DOPUtils.natural_language_first_value(titles)
                     else:

--- a/csvwlib/utils/DOPUtils.py
+++ b/csvwlib/utils/DOPUtils.py
@@ -7,4 +7,4 @@ class DOPUtils:
         if type(property_value) is str:
             return property_value
         elif type(property_value) is list:
-            return property_value[0]
+            return next(iter(property_value or []), None)


### PR DESCRIPTION
especially in virtual columns the col:name and col:titles property should not be required

this PR sets them as None instead of throwing error

it enables col definitions such as:

 ```json
{"columns": [
          {
            "virtual": true,
            "propertyUrl": "rdf:type",
            "valueUrl": "qudt:QuantityValue",
            "aboutUrl": "https://example.com/example3/{SAMPLE}/K/QV"
          },
          {
            "virtual": true,
            "propertyUrl": "qudt:unit",
            "aboutUrl": "https://example.com/example3/{SAMPLE}/K/QV",
            "valueUrl": "http://qudt.org/vocab/unit/MicroMOL-PER-KiloGM"
          }
]}
```

