### PR TITLE
enables to set a (default) value for virtual columns,

### DIFF
--- a/csvwlib/converter/ModelConverter.py
+++ b/csvwlib/converter/ModelConverter.py
@@ -270,7 +270,7 @@ class ModelConverter:
             for i, column_metadata in enumerate(table_metadata['tableSchema']['columns']):
                 if 'default' in column_metadata:
                     for row in csv:
-                        if row[i] == '':
+                        if i < len(row) and row[i] == '':
                             row[i] = column_metadata['default']
 
     def _normalize_numbers_notation(self):

--- a/csvwlib/converter/ToRDFConverter.py
+++ b/csvwlib/converter/ToRDFConverter.py
@@ -71,12 +71,18 @@ class ToRDFConverter:
             subject = URIRef(UriTemplateUtils.insert_value(virtual_column['aboutUrl'], atdm_row, '',
                                                            table_metadata['url']))
             predicate = Namespaces.get_term(virtual_column['propertyUrl'])
-            obj = UriTemplateUtils.insert_value(virtual_column['valueUrl'], atdm_row, '', table_metadata['url'])
-            obj = CommonProperties.expand_property_if_possible(obj)
-            self.graph.add((subject, predicate, URIRef(obj)))
-            if self.mode == CONST_STANDARD_MODE:
-                self.graph.add((row_node, CSVW.describes, subject))
-
+            if predicate:
+                if 'valueUrl' in virtual_column:
+                    obj = UriTemplateUtils.insert_value(virtual_column['valueUrl'], atdm_row, '', table_metadata['url'])
+                    obj = CommonProperties.expand_property_if_possible(obj)
+                    self.graph.add((subject, predicate, URIRef(obj)))
+                elif 'default' in virtual_column: 
+                    self.graph.add((subject, predicate, self._object_node(virtual_column['default'], virtual_column, atdm_row, '')))
+                if self.mode == CONST_STANDARD_MODE:
+                    self.graph.add((row_node, CSVW.describes, subject))
+            else:
+                print(f"term {virtual_column['propertyUrl']} not in namespaces")
+S
     def _add_file_metadata(self, metadata, node):
         language = JSONLDUtils.language(self.metadata['@context'])
         for key, value in metadata.items():


### PR DESCRIPTION
`default` keyword as described in https://www.w3.org/ns/csvw#property-definitions can set a value in virtual columns from context
also fixes a bug when column number is outside nr of columns (due to virtual columns)
a sample context file with usage of this approach is at https://github.com/soilwise-he/soilwise-ontology/blob/main/CSVW-Excel-Template/example3/obs.csv-metadata.json